### PR TITLE
rename metrics and add apiElapsedTime

### DIFF
--- a/exporter.cfg
+++ b/exporter.cfg
@@ -24,8 +24,8 @@ QueryOnMissing = drop
 # Queries are defined in sections beginning with 'query_'.
 # Characters following this prefix will be used as a prefix for all metrics
 # generated for this query
-# for merchant discovery latency event 
-[query_merchant_discovery]
+# for merchant discovery latency event: olaElapsedTime 
+[query_ola_merchant_discovery]
 # The DEFAULT settings can be overridden.
 QueryIndices = overwatch-core-*
 QueryJson = {
@@ -83,7 +83,7 @@ QueryJson = {
     }  
   }
 # 95 percentile
-[query_merchant_discovery_latencies]
+[query_ola_merchant_discovery_latencies]
 # The DEFAULT settings can be overridden.
 QueryIndices = overwatch-core-*
 QueryJson = {
@@ -143,8 +143,127 @@ QueryJson = {
       }
     }  
   }
-# for get invoice latencies event 
-[query_get_invoice]
+# for merchant discovery latency event: apiElapsedTime 
+[query_api_merchant_discovery]
+# The DEFAULT settings can be overridden.
+QueryIndices = overwatch-core-*
+QueryJson = {
+    "aggs": {
+      "latencies": {
+        "avg": {
+          "field": "apiElapsedTime"
+        }
+      }
+    },
+    "size": 0,
+    "stored_fields": [
+      "*"
+    ],
+    "script_fields": {},
+    "docvalue_fields": [
+      {
+        "field": "@timestamp",
+        "format": "date_time"
+      }
+    ],
+    "_source": {
+      "excludes": []
+    },
+    "query": {
+      "bool": {
+        "must": [],
+        "filter": [
+          {
+            "match_all": {}
+          },
+          {
+            "match_phrase": {
+              "name.keyword": "DISCOVERY_MS"
+            }
+          },
+          {
+            "match_phrase": {
+              "eventType.keyword": "SLO"
+            }
+          },
+          {
+            "range": {
+              "@timestamp": {
+                  "gte": "now-1m/m",
+                  "lt": "now/m",
+                  "format": "strict_date_optional_time"
+              }
+            }
+          }
+        ],
+        "should": [],
+        "must_not": []
+      }
+    }  
+  }
+# 95 percentile
+[query_api_merchant_discovery_latencies]
+# The DEFAULT settings can be overridden.
+QueryIndices = overwatch-core-*
+QueryJson = {
+    "aggs": {
+      "95percentiles": {
+        "percentiles": {
+          "field": "apiElapsedTime",
+          "percents": [
+            95
+          ]
+        }
+      }
+    },
+    "size": 0,
+    "stored_fields": [
+      "*"
+    ],
+    "script_fields": {},
+    "docvalue_fields": [
+      {
+        "field": "@timestamp",
+        "format": "date_time"
+      }
+    ],
+    "_source": {
+      "excludes": []
+    },
+    "query": {
+      "bool": {
+        "must": [],
+        "filter": [
+          {
+            "match_all": {}
+          },
+          {
+            "match_phrase": {
+              "name.keyword": "DISCOVERY_MS"
+            }
+          },
+          {
+            "match_phrase": {
+              "eventType.keyword": "SLO"
+            }
+          },
+          {
+            "range": {
+              "@timestamp": {
+                  "gte": "now-1m/m",
+                  "lt": "now/m",
+                  "format": "strict_date_optional_time"
+              }
+            }
+          }
+        ],
+        "should": [],
+        "must_not": []
+      }
+    }  
+  }
+# for get invoice latencies event: olaElapsedTime 
+[query_ola_get_invoice]
 # The DEFAULT settings can be overridden.
 QueryIndices = overwatch-core-*
 QueryJson = {
@@ -201,8 +320,8 @@ QueryJson = {
       }
     }
   }
-# 95 percentile 
-[query_get_invoice_latencies]
+# 95 percentile: olaElapsedTime
+[query_ola_get_invoice_latencies]
 # The DEFAULT settings can be overridden.
 QueryIndices = overwatch-core-*
 QueryJson = {
@@ -210,6 +329,125 @@ QueryJson = {
       "95percentiles": {
         "percentiles": {
           "field": "olaElapsedTime",
+          "percents": [
+            95
+          ]
+        }
+      }
+    },
+    "size": 0,
+    "stored_fields": [
+      "*"
+    ],
+    "script_fields": {},
+    "docvalue_fields": [
+      {
+        "field": "@timestamp",
+        "format": "date_time"
+      }
+    ],
+    "_source": {
+      "excludes": []
+    },
+    "query": {
+      "bool": {
+        "must": [],
+        "filter": [
+          {
+            "match_all": {}
+          },
+          {
+            "match_phrase": {
+              "name.keyword": "INVOICING"
+            }
+          },
+          {
+            "match_phrase": {
+              "eventType.keyword": "SLO"
+            }
+          },
+          {
+            "range": {
+              "@timestamp": {
+                  "gte": "now-1m/m",
+                  "lt": "now/m",
+                  "format": "strict_date_optional_time"
+              }
+            }
+          }
+        ],
+        "should": [],
+        "must_not": []
+      }
+    }
+  }
+# for get invoice latencies event: apiElapsedTime 
+[query_api_get_invoice]
+# The DEFAULT settings can be overridden.
+QueryIndices = overwatch-core-*
+QueryJson = {
+    "aggs": {
+      "latencies": {
+        "avg": {
+          "field": "apiElapsedTime"
+        }
+      }
+    },
+    "size": 0,
+    "stored_fields": [
+      "*"
+    ],
+    "script_fields": {},
+    "docvalue_fields": [
+      {
+        "field": "@timestamp",
+        "format": "date_time"
+      }
+    ],
+    "_source": {
+      "excludes": []
+    },
+    "query": {
+      "bool": {
+        "must": [],
+        "filter": [
+          {
+            "match_all": {}
+          },
+          {
+            "match_phrase": {
+              "name.keyword": "INVOICING"
+            }
+          },
+          {
+            "match_phrase": {
+              "eventType.keyword": "SLO"
+            }
+          },
+          {
+            "range": {
+              "@timestamp": {
+                  "gte": "now-1m/m",
+                  "lt": "now/m",
+                  "format": "strict_date_optional_time"
+              }
+            }
+          }
+        ],
+        "should": [],
+        "must_not": []
+      }
+    }
+  }
+# 95 percentile: apiElapsedTime
+[query_api_get_invoice_latencies]
+# The DEFAULT settings can be overridden.
+QueryIndices = overwatch-core-*
+QueryJson = {
+    "aggs": {
+      "95percentiles": {
+        "percentiles": {
+          "field": "apiElapsedTime",
           "percents": [
             95
           ]


### PR DESCRIPTION
Export the following metrics from ES to Prom for monitoring latencies

- ow_core - Merchant Discovery Latencies (ms): DISCOVERY_MS olaElapsedTime and apiElapsedTime in SLO event

> - ola_merchant_discovery_latencies_value
> - ola_merchant_discovery_latencies_95percentiles_values_95_0
> - api_merchant_discovery_latencies_value
> - api_merchant_discovery_latencies_95percentiles_values_95_0

- ow_core - Get Invoice Latencies (ms): INVOICING olaElapsedTime and apiElapsedTime in SLO event

> - ola_get_invoice_latencies_value
> - ola_get_invoice_latencies_95percentiles_values_95_0
> - api_get_invoice_latencies_value
> - api_get_invoice_latencies_95percentiles_values_95_0

- ow_core - Quote For Payment Latencies (ms): USERS_QUOTE_FOR_PAYMENT elapsedTime in API event

> - quote_for_payment_latencies_value
> - quote_for_payment_latencies_95percentiles_values_95_0

- ow_core - Pay Latencies (ms): U_PAY elapsedTime in JOB_TERMINAL event

> - pay_latencies_value
> - pay_latencies_95percentiles_values_95_0
